### PR TITLE
refactor: use openapi-fetch for generated exam

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -33,13 +33,19 @@ if (import.meta.env.VITE_MOCK_DATA === "true" && import.meta.env.PROD) {
 const queryClient = new QueryClient();
 
 const examLoader: LoaderFunction = async ({ params }) => {
-  const examData = await getGeneratedExam(params.examId!);
-  if (examData.code) {
+  const res = await getGeneratedExam(params.examId!);
+
+  if (res.response.status === 500) {
+    return redirect("/error?errorInfo='Server error fetching generated exam'");
+  }
+  if (res.error?.code) {
     // TODO: Prevent camera from starting up
     return redirect(
-      `/landing?flashKind=warning&flashMessage=${examData.message}`
+      `/landing?flashKind=warning&flashMessage=${res.error.message}`
     );
   }
+
+  const examData = res.data;
 
   return examData;
 };

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -136,15 +136,11 @@ export async function getExams() {
   return data;
 }
 
-type Ua = keyof paths;
-type Ma<U extends Ua> = keyof paths[U];
-type X<U extends Ua, M extends Ma<U>> = paths[U][M];
-
 function openapiFetchResponse<
-  Url extends Ua,
-  Method extends Ma<Url>,
-  T extends X<Url, Method>
->(data: T["responses"]): FetchResponse<T, FetchOptions<T>, "application/json"> {
+  Url extends keyof paths,
+  Method extends keyof paths[Url],
+  T extends paths[Url][Method]["responses"]["200"]["content"]["application/json"]
+>(data: T): FetchResponse<T, FetchOptions<T>, "application/json"> {
   return {
     data,
     response: new Response(null, { status: 200 }),

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -48,8 +48,7 @@ export async function getGeneratedExam(examId: string) {
 
     const res = openapiFetchResponse<
       "/exam-environment/exam/generated-exam",
-      "post",
-      typeof generatedExam
+      "post"
     >(generatedExam);
     return res;
   }
@@ -137,16 +136,15 @@ export async function getExams() {
   return data;
 }
 
+type Ua = keyof paths;
+type Ma<U extends Ua> = keyof paths[U];
+type X<U extends Ua, M extends Ma<U>> = paths[U][M];
+
 function openapiFetchResponse<
-  Url extends keyof paths,
-  Method extends keyof paths[Url] &
-    ("get" | "post" | "put" | "delete" | "patch"),
-  T extends paths[Url][Method] extends {
-    responses: { "200": { content: { "application/json": any } } };
-  }
-    ? paths[Url][Method]["responses"]["200"]["content"]["application/json"]
-    : never
->(data: T): FetchResponse<T, FetchOptions<T>, "application/json"> {
+  Url extends Ua,
+  Method extends Ma<Url>,
+  T extends X<Url, Method>
+>(data: T["responses"]): FetchResponse<T, FetchOptions<T>, "application/json"> {
   return {
     data,
     response: new Response(null, { status: 200 }),

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -2,7 +2,11 @@ import { invoke } from "@tauri-apps/api/core";
 import { fetch } from "@tauri-apps/plugin-http";
 import { UserExamAttempt } from "./types";
 
-import createClient, { FetchOptions, FetchResponse } from "openapi-fetch";
+import createClient, {
+  Client,
+  FetchOptions,
+  FetchResponse,
+} from "openapi-fetch";
 import type { paths } from "../../prisma/api-schema";
 
 const client = createClient<paths>({
@@ -136,11 +140,17 @@ export async function getExams() {
   return data;
 }
 
+type Resp<
+  P extends keyof paths,
+  Method extends keyof paths[P]
+> = paths[P] extends { [key in Method]: unknown } ? paths[P][Method] : never;
+
 function openapiFetchResponse<
   Url extends keyof paths,
   Method extends keyof paths[Url],
-  T extends paths[Url][Method]["responses"]["200"]["content"]["application/json"]
->(data: T): FetchResponse<T, FetchOptions<T>, "application/json"> {
+  T extends Resp<Url, Method>
+>(data: T) {
+  // >(data: T): FetchResponse<T, FetchOptions<T>, "application/json"> {
   return {
     data,
     response: new Response(null, { status: 200 }),

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -2,11 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { fetch } from "@tauri-apps/plugin-http";
 import { UserExamAttempt } from "./types";
 
-import createClient, {
-  Client,
-  FetchOptions,
-  FetchResponse,
-} from "openapi-fetch";
+import createClient from "openapi-fetch";
 import type { paths } from "../../prisma/api-schema";
 
 const client = createClient<paths>({
@@ -50,11 +46,11 @@ export async function getGeneratedExam(examId: string) {
     ).json()) as paths["/exam-environment/exam/generated-exam"]["post"]["responses"]["200"]["content"]["application/json"];
     generatedExam.examAttempt.startTimeInMS = Date.now();
 
-    const res = openapiFetchResponse<
-      "/exam-environment/exam/generated-exam",
-      "post"
-    >(generatedExam);
-    return res;
+    return {
+      data: generatedExam,
+      response: new Response(null, { status: 200 }),
+      error: undefined,
+    };
   }
 
   const token = await invoke<string>("get_authorization_token");
@@ -138,21 +134,4 @@ export async function getExams() {
   console.debug(data);
 
   return data;
-}
-
-type Resp<
-  P extends keyof paths,
-  Method extends keyof paths[P]
-> = paths[P] extends { [key in Method]: unknown } ? paths[P][Method] : never;
-
-function openapiFetchResponse<
-  Url extends keyof paths,
-  Method extends keyof paths[Url],
-  T extends Resp<Url, Method>
->(data: T) {
-  // >(data: T): FetchResponse<T, FetchOptions<T>, "application/json"> {
-  return {
-    data,
-    response: new Response(null, { status: 200 }),
-  };
 }


### PR DESCRIPTION
- Use openapi fetch for `/generated-exam` endpoint