### PR TITLE
fix: reset audio on unmount

### DIFF
--- a/public/mocks/exams.json
+++ b/public/mocks/exams.json
@@ -72,7 +72,7 @@
               "deprecated": false,
               "audio": {
                 "captions": null,
-                "url": "curriculum/english/animation-assets/sounds/1.1-1.mp3"
+                "url": "https://cdn.freecodecamp.org/curriculum/english/animation-assets/sounds/1.1-1.mp3"
               },
               "tags": [],
               "text": "This is an example of a multiple-choice question with audio. Listen to the audio to answer this question: When was freeCodeCamp started?",

--- a/public/mocks/generated-exam.json
+++ b/public/mocks/generated-exam.json
@@ -14,7 +14,7 @@
     "config": {
       "name": "First Exam",
       "note": "This exam includes listening comprehension",
-      "totalTimeInMS": 30000
+      "totalTimeInMS": 600000
     },
     "questionSets": [
       {
@@ -42,6 +42,74 @@
               {
                 "id": "66b522e714a1cd98b5d3dc08",
                 "text": "Madrid"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "6748182f0f9d6e80fa2eb04d",
+        "type": "MultipleChoice",
+        "context": null,
+        "questions": [
+          {
+            "id": "674818354cd5f347eb35df91",
+            "deprecated": false,
+            "audio": {
+              "captions": null,
+              "url": "https://cdn.freecodecamp.org/curriculum/english/animation-assets/sounds/1.1-1.mp3"
+            },
+            "text": "This is an example of a multiple-choice question with audio. Listen to the audio to answer this question: When was freeCodeCamp started?",
+            "answers": [
+              {
+                "id": "6748183cbc00e4a0a3c2ebf8",
+                "text": "2014"
+              },
+              {
+                "id": "674818446784013ac9152ec1",
+                "text": "2010"
+              },
+              {
+                "id": "67481849a2178d78a1c33fc0",
+                "text": "2016"
+              },
+              {
+                "id": "6748184f8ec2864e9138a127",
+                "text": "2019"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "id": "6748182f0f9d6e80fa2eb04e",
+        "type": "MultipleChoice",
+        "context": null,
+        "questions": [
+          {
+            "id": "674818354cd5f347eb35df92",
+            "deprecated": false,
+            "audio": {
+              "captions": null,
+              "url": "https://cdn.freecodecamp.org/curriculum/english/animation-assets/sounds/1.1-1.mp3"
+            },
+            "text": "This is a continuation of the same audio question from the previous. When was `freeCodeCamp` founded?",
+            "answers": [
+              {
+                "id": "6748183cbc00e4a0a3c2ebf9",
+                "text": "2014"
+              },
+              {
+                "id": "674818446784013ac9152ec2",
+                "text": "2010"
+              },
+              {
+                "id": "67481849a2178d78a1c33fc1",
+                "text": "2016"
+              },
+              {
+                "id": "6748184f8ec2864e9138a128",
+                "text": "2019"
               }
             ]
           }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -30,16 +30,20 @@ pub async fn take_screenshot(window: Window) -> Result<(), Error> {
             .map_err(|e| Error::Screenshot(format!("Unable to capture screen: {}", e)))
             .capture()?;
 
-        // Inability to set window to content_protected == true should not prevent continuation
-        let _window_protected = window
-            .set_content_protected(true)
-            .map_err(|e| {
-                Error::Screenshot(format!(
-                    "Unable to set window back to protected mode after screenshot: {}",
-                    e
-                ))
-            })
-            .capture();
+        // If in debug mode, do not set the window back to protected mode.
+        #[cfg(not(debug_assertions))]
+        {
+            // Inability to set window to content_protected == true should not prevent continuation
+            let _window_protected = window
+                .set_content_protected(true)
+                .map_err(|e| {
+                    Error::Screenshot(format!(
+                        "Unable to set window back to protected mode after screenshot: {}",
+                        e
+                    ))
+                })
+                .capture();
+        }
 
         let image = utils::image_to_bytes(main_screen_img);
         post_screenshot(image).await?;

--- a/src/components/audio-player.tsx
+++ b/src/components/audio-player.tsx
@@ -60,7 +60,11 @@ export function AudioPlayer({ fullQuestion }: AudioPlayerProps) {
     if (!audioRef.current) {
       return;
     }
-    setProgress(audioRef.current.currentTime);
+    const currentTime = audioRef.current.currentTime;
+    if (typeof currentTime !== "number") {
+      return;
+    }
+    setProgress(currentTime);
   }
 
   function onPause() {
@@ -106,7 +110,7 @@ export function AudioPlayer({ fullQuestion }: AudioPlayerProps) {
       <Flex direction="column">
         <Flex alignItems="center">
           <Button onClick={togglePlay}>
-            {isPlaying ? "=" : <TriangleUpIcon style={{ rotate: "90deg" }} />}
+            {isPlaying ? "| |" : <TriangleUpIcon style={{ rotate: "90deg" }} />}
           </Button>
           <Text ml={2}>
             {formatTime(audioRef.current.currentTime)} / {formatTime(duration)}

--- a/src/components/audio-player.tsx
+++ b/src/components/audio-player.tsx
@@ -1,0 +1,121 @@
+import { TriangleUpIcon } from "@chakra-ui/icons";
+import {
+  Box,
+  Button,
+  Flex,
+  Slider,
+  SliderFilledTrack,
+  SliderThumb,
+  SliderTrack,
+  Text,
+} from "@chakra-ui/react";
+import { useEffect, useRef, useState } from "react";
+import { FullQuestion } from "../utils/types";
+
+interface AudioPlayerProps {
+  fullQuestion: FullQuestion;
+}
+
+export function AudioPlayer({ fullQuestion }: AudioPlayerProps) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [duration, setDuration] = useState(0);
+
+  useEffect(() => {
+    if (!fullQuestion.audio) {
+      return;
+    }
+    audioRef.current = new Audio(fullQuestion.audio.url);
+
+    audioRef.current.onloadedmetadata = onLoadedMetadata;
+    audioRef.current.ontimeupdate = onTimeUpdate;
+    audioRef.current.onpause = onPause;
+    audioRef.current.onplay = onPlay;
+
+    return () => {
+      if (!audioRef.current) {
+        return;
+      }
+      audioRef.current.pause();
+      audioRef.current = null;
+    };
+  }, [fullQuestion]);
+
+  function onLoadedMetadata() {
+    if (!audioRef.current) {
+      return;
+    }
+    setDuration(audioRef.current.duration);
+  }
+
+  function onTimeUpdate() {
+    if (!audioRef.current) {
+      return;
+    }
+    setProgress(audioRef.current.currentTime);
+  }
+
+  function onPause() {
+    setIsPlaying(false);
+  }
+
+  function onPlay() {
+    setIsPlaying(true);
+  }
+
+  const togglePlay = () => {
+    if (isPlaying) {
+      audioRef.current?.pause();
+    } else {
+      audioRef.current?.play();
+    }
+  };
+
+  function handleSeek(value: number) {
+    if (!audioRef.current) {
+      return;
+    }
+    audioRef.current.currentTime = value;
+    setProgress(value);
+  }
+
+  function formatTime(time: number): string {
+    const minutes = Math.floor(time / 60);
+    const seconds = Math.floor(time % 60);
+    return `${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;
+  }
+
+  if (!audioRef.current || !fullQuestion.audio) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <Flex direction="column">
+        <Flex alignItems="center">
+          <Button onClick={togglePlay}>
+            {isPlaying ? "=" : <TriangleUpIcon style={{ rotate: "90deg" }} />}
+          </Button>
+          <Text ml={2}>
+            {formatTime(audioRef.current.currentTime)} / {formatTime(duration)}
+          </Text>
+        </Flex>
+
+        <Slider
+          aria-label="slider-ex-1"
+          min={0}
+          max={duration}
+          value={progress}
+          onChange={(val) => handleSeek(val)}
+        >
+          <SliderTrack>
+            <SliderFilledTrack />
+          </SliderTrack>
+          <SliderThumb />
+        </Slider>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/components/audio-player.tsx
+++ b/src/components/audio-player.tsx
@@ -28,6 +28,8 @@ export function AudioPlayer({ fullQuestion }: AudioPlayerProps) {
       return;
     }
     audioRef.current = new Audio(fullQuestion.audio.url);
+    setIsPlaying(false);
+    setProgress(0);
 
     audioRef.current.onloadedmetadata = onLoadedMetadata;
     audioRef.current.ontimeupdate = onTimeUpdate;
@@ -47,7 +49,11 @@ export function AudioPlayer({ fullQuestion }: AudioPlayerProps) {
     if (!audioRef.current) {
       return;
     }
-    setDuration(audioRef.current.duration);
+    const d = audioRef.current.duration;
+    if (typeof d !== "number") {
+      return;
+    }
+    setDuration(d);
   }
 
   function onTimeUpdate() {
@@ -81,7 +87,11 @@ export function AudioPlayer({ fullQuestion }: AudioPlayerProps) {
     setProgress(value);
   }
 
-  function formatTime(time: number): string {
+  function formatTime(time: unknown): string {
+    if (typeof time !== "number") {
+      // Somehow, `audioRef.current.currentTime` can be unset
+      return "0:00";
+    }
     const minutes = Math.floor(time / 60);
     const seconds = Math.floor(time % 60);
     return `${minutes}:${seconds < 10 ? "0" : ""}${seconds}`;

--- a/src/components/question-set-form.tsx
+++ b/src/components/question-set-form.tsx
@@ -1,11 +1,12 @@
-import { QuizQuestion } from "@freecodecamp/ui";
+import { UseMutationResult } from "@tanstack/react-query";
 import { Box, Text, Spacer } from "@chakra-ui/react";
-import { useEffect, useState, useRef } from "react";
+import { QuizQuestion } from "@freecodecamp/ui";
 import Markdown from "markdown-to-jsx";
+import { useEffect } from "react";
 
 import { Answers, FullQuestion, UserExamAttempt } from "../utils/types";
 import { ButtonLoading } from "./button-loading";
-import { UseMutationResult } from "@tanstack/react-query";
+import { AudioPlayer } from "./audio-player";
 
 type QuestionTypeFormProps = {
   fullQuestion: FullQuestion;
@@ -31,23 +32,6 @@ export function QuestionSetForm({
   setNewSelectedAnswers,
   examAttempt,
 }: QuestionTypeFormProps) {
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const [audioSource, setAudioSource] = useState("");
-  function resetAudio() {
-    if (audioRef.current) {
-      // This is to prevent a stupid UI bug (all Shaun's fault)
-      audioRef.current.load();
-      audioRef.current
-        .play()
-        .then(() => {
-          if (audioRef.current) {
-            audioRef.current.pause();
-          }
-        })
-        .catch(console.error);
-    }
-  }
-
   useEffect(() => {
     setNewSelectedAnswers(
       fullQuestion.answers
@@ -58,17 +42,7 @@ export function QuestionSetForm({
         )
         .map((a) => a.id)
     );
-    if (fullQuestion.audio) {
-      setAudioSource(fullQuestion.audio.url);
-    }
-    return () => {
-      // https://github.com/freeCodeCamp/exam-env/issues/21
-      // This is done during unmount to ensure the audio pauses after submission.
-      resetAudio();
-    };
   }, [fullQuestion]);
-
-  useEffect(resetAudio, [audioSource]);
 
   return (
     <>
@@ -78,15 +52,11 @@ export function QuestionSetForm({
           <Markdown>{fullQuestion.questionSet.context}</Markdown>
         </>
       )}
-      {fullQuestion.audio?.url && (
+      {fullQuestion.audio && (
         <Box mb={"2em"} mt={"2em"}>
           <Text>Please listen to the following audio fragment:</Text>
-          <audio
-            controls
-            controlsList="nodownload"
-            ref={audioRef}
-            src={audioSource}
-          ></audio>
+          {/* NOTE: `fullQuestion` is passed to cause the whole component to rerender - correctly resetting the audio */}
+          <AudioPlayer fullQuestion={fullQuestion} />
         </Box>
       )}
       <Text fontWeight={"bold"}>Question</Text>

--- a/src/components/question-set-form.tsx
+++ b/src/components/question-set-form.tsx
@@ -33,7 +33,7 @@ export function QuestionSetForm({
 }: QuestionTypeFormProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [audioSource, setAudioSource] = useState("");
-  const loadNextAudio = () => {
+  function resetAudio() {
     if (audioRef.current) {
       // This is to prevent a stupid UI bug (all Shaun's fault)
       audioRef.current.load();
@@ -46,7 +46,7 @@ export function QuestionSetForm({
         })
         .catch(console.error);
     }
-  };
+  }
 
   useEffect(() => {
     setNewSelectedAnswers(
@@ -61,9 +61,14 @@ export function QuestionSetForm({
     if (fullQuestion.audio) {
       setAudioSource(fullQuestion.audio.url);
     }
+    return () => {
+      // https://github.com/freeCodeCamp/exam-env/issues/21
+      // This is done during unmount to ensure the audio pauses after submission.
+      resetAudio();
+    };
   }, [fullQuestion]);
 
-  useEffect(loadNextAudio, [audioSource]);
+  useEffect(resetAudio, [audioSource]);
 
   return (
     <>

--- a/src/components/question-set-form.tsx
+++ b/src/components/question-set-form.tsx
@@ -33,9 +33,8 @@ export function QuestionSetForm({
 }: QuestionTypeFormProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [audioSource, setAudioSource] = useState("");
-  function resetAudio() {
+  function loadNextAudio() {
     if (audioRef.current) {
-      // This is to prevent a stupid UI bug (all Shaun's fault)
       audioRef.current.load();
       audioRef.current
         .play()
@@ -63,12 +62,15 @@ export function QuestionSetForm({
     }
     return () => {
       // https://github.com/freeCodeCamp/exam-env/issues/21
-      // This is done during unmount to ensure the audio pauses after submission.
-      resetAudio();
+      // on unmount/re-render we need to reset the audio source to prevent the audio from playing
+      // when the user navigates to another question.
+      if (audioRef.current) {
+        audioRef.current.src = audioSource;
+      }
     };
   }, [fullQuestion]);
 
-  useEffect(resetAudio, [audioSource]);
+  useEffect(loadNextAudio, [audioSource]);
 
   return (
     <>

--- a/src/components/question-set-form.tsx
+++ b/src/components/question-set-form.tsx
@@ -33,8 +33,9 @@ export function QuestionSetForm({
 }: QuestionTypeFormProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [audioSource, setAudioSource] = useState("");
-  function loadNextAudio() {
+  function resetAudio() {
     if (audioRef.current) {
+      // This is to prevent a stupid UI bug (all Shaun's fault)
       audioRef.current.load();
       audioRef.current
         .play()
@@ -62,15 +63,12 @@ export function QuestionSetForm({
     }
     return () => {
       // https://github.com/freeCodeCamp/exam-env/issues/21
-      // on unmount/re-render we need to reset the audio source to prevent the audio from playing
-      // when the user navigates to another question.
-      if (audioRef.current) {
-        audioRef.current.src = audioSource;
-      }
+      // This is done during unmount to ensure the audio pauses after submission.
+      resetAudio();
     };
   }, [fullQuestion]);
 
-  useEffect(loadNextAudio, [audioSource]);
+  useEffect(resetAudio, [audioSource]);
 
   return (
     <>


### PR DESCRIPTION
Closes #21 

The extra questions were added to show a case where the audio url does not change between questions.

Also, this disables the re-enabling of window content protection when `tauri dev` or `tauri build --debug` is used.