### PR TITLE
fix: improve camera access error handling and permission checks

### DIFF
--- a/src/components/camera.tsx
+++ b/src/components/camera.tsx
@@ -28,8 +28,15 @@ export function Camera({
       const stream = await navigator.mediaDevices.getUserMedia(
         constraints || { video: true }
       );
-      const video = videoRef.current;
 
+      stream.getTracks().forEach((track) => {
+        track.addEventListener("ended", () => {
+          onUserMediaSetupError(
+            "Your Camera is not accessible. Please allow access to your camera and refresh the page."
+          );
+        });
+      });
+      const video = videoRef.current;
       if (video) {
         video.srcObject = stream;
         // Video is "paused" when component is unmounted :shrug:
@@ -38,11 +45,6 @@ export function Camera({
           stream.getTracks().forEach((track) => {
             track.stop();
           });
-        };
-        // Event "suspend" is emitted if permissions are revoked for camera
-        video.onsuspend = (e) => {
-          console.debug(e);
-          onUserMediaSetupError("Camera is unavailable.");
         };
       }
     } catch (err) {

--- a/src/components/camera.tsx
+++ b/src/components/camera.tsx
@@ -30,11 +30,11 @@ export function Camera({
       );
 
       stream.getTracks().forEach((track) => {
-        track.addEventListener("ended", () => {
+        track.onended = () => {
           onUserMediaSetupError(
             "Your Camera is not accessible. Please allow access to your camera and refresh the page."
           );
-        });
+        };
       });
       const video = videoRef.current;
       if (video) {

--- a/src/pages/splashscreen.tsx
+++ b/src/pages/splashscreen.tsx
@@ -348,6 +348,12 @@ async function updateDeviceList() {
       return new Error(`Unable to access camera. ${e}`);
     }
 
+    if (cameraPermission.state === "prompt") {
+      return new Error(
+        "Camera permission not granted. Please allow camera access."
+      );
+    }
+
     if (cameraPermission.state !== "granted") {
       return new Error("Camera permission denied. Please allow camera access.");
     }


### PR DESCRIPTION
`onsuspend` event fires on media elements (like `<video>` or `<audio>`) when the browser intentionally pauses loading more data because it has enough buffered, or the browser chooses to suspend further data fetching temporarily.

I can't test this well because my camera is built-in. I don't think we really have to worry about permissions being revoked during the exam. I suspect/assume that when revoking permissions during the exam will cause them to take effect after re-launching the environment.

The first permission check (when you start up the environment) only checks if the access wasn't granted. Thus giving a "denied" message. But on MacOS the camera permission state will start with "prompt". Although the permission already has been granted in development. If we want to change this behaviour I suspect that we need to reset those permissions when starting a new dev session.