### PR TITLE
fix: include license in bundle

### DIFF
--- a/backend/tauri.conf.json
+++ b/backend/tauri.conf.json
@@ -43,7 +43,7 @@
       }
     },
     "publisher": "Free Code Camp, Inc.",
-    "resources": [],
+    "resources": ["../LICENSE.md"],
     "targets": "all",
     "windows": {
       "signCommand": "relic sign --file %1 --key azure --config relic.conf"

--- a/backend/tauri.conf.json
+++ b/backend/tauri.conf.json
@@ -43,7 +43,7 @@
       }
     },
     "publisher": "Free Code Camp, Inc.",
-    "resources": ["../LICENSE.md"],
+    "resources": [],
     "targets": "all",
     "windows": {
       "signCommand": "relic sign --file %1 --key azure --config relic.conf"

--- a/backend/tauri.conf.json
+++ b/backend/tauri.conf.json
@@ -52,7 +52,8 @@
       "appimage": {
         "bundleMediaFramework": true
       }
-    }
+    },
+    "licenseFile": "../LICENSE.md"
   },
   "plugins": {
     "deep-link": {


### PR DESCRIPTION
avoids separate bundling of license file sourced from repo. useful for the aur package of exam-env