### PR TITLE
fix: prevent query function re-render

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4333,9 +4333,9 @@ dependencies = [
 
 [[package]]
 name = "sentry"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
+checksum = "b93b3e19f45495ddd41d8222a152c48c84f6ba45abe9c69e2527e9cdea29bb5b"
 dependencies = [
  "cfg_aliases",
  "httpdate",
@@ -4355,9 +4355,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-actix"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9453d18fc9a45d841636004aad50288d80cc07c34a9e88cd4397cb66e6356f67"
+checksum = "168d0312e1b1741d8295a16c7b2c62c10c76302f7476a1749d6ccc14cb40663a"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -4368,9 +4368,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-backtrace"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a8c2c1bd5c1f735e84f28b48e7d72efcaafc362b7541bc8253e60e8fcdffc6"
+checksum = "dc84c325ace9ca2388e510fe7d6672b5d60cd8b3bd0eb4bb4ee8314c323cd686"
 dependencies = [
  "backtrace",
  "regex",
@@ -4379,9 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-contexts"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b88a90baa654d7f0e1f4b667f6b434293d9f72c71bef16b197c76af5b7d5803"
+checksum = "896c1ab62dbfe1746fb262bbf72e6feb2fb9dfb2c14709077bf71beb532e44b2"
 dependencies = [
  "hostname",
  "libc",
@@ -4393,9 +4393,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-core"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac170a5bba8bec6e3339c90432569d89641fa7a3d3e4f44987d24f0762e6adf"
+checksum = "d5f5abf20c42cb1593ec1638976e2647da55f79bccac956444c1707b6cce259a"
 dependencies = [
  "rand 0.9.4",
  "sentry-types",
@@ -4406,9 +4406,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-debug-images"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd9646a972b57896d4a92ed200cf76139f8e30b3cfd03b6662ae59926d26633c"
+checksum = "4b88bbe6a760d5724bb40689827e82e8db1e275947df2c59abe171bfc30bb671"
 dependencies = [
  "findshlibs",
  "sentry-core",
@@ -4416,9 +4416,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-log"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235865e639f1d72414fa5d35374e105c292e2ee3a2f90919d961bbb486626ee6"
+checksum = "5a8d7875e460bffe85150b5a452834cc3c9a7696df7693f6024320097bdd2a2d"
 dependencies = [
  "bitflags 2.11.1",
  "log",
@@ -4427,9 +4427,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-panic"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6127d3d304ba5ce0409401e85aae538e303a569f8dbb031bf64f9ba0f7174346"
+checksum = "0260dcb52562b6a79ae7702312a26dba94b79fb5baee7301087529e5ca4e872e"
 dependencies = [
  "sentry-backtrace",
  "sentry-core",
@@ -4437,9 +4437,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-tracing"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27701acc51e68db5281802b709010395bfcbcb128b1d0a4e5873680d3b47ff0c"
+checksum = "a1c035f3a0a8671ae1a231c5b457abb68b71acba2bf3054dab2a09a9d4ea487e"
 dependencies = [
  "bitflags 2.11.1",
  "sentry-backtrace",
@@ -4450,9 +4450,9 @@ dependencies = [
 
 [[package]]
 name = "sentry-types"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56780cb5597d676bf22e6c11d1f062eb4def46390ea3bfb047bcbcf7dfd19bdb"
+checksum = "82d8e81058ec155992191f61c7b29bfa7b2cf12012131e7cdc0678020898a7c9"
 dependencies = [
  "debugid",
  "hex",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,7 +16,7 @@ tauri = { version = "2.10.3", features = ["macos-private-api"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri-plugin-dialog = "2.6.0"
-sentry = { version = "0.47.0", features = ["tracing", "logs"] }
+sentry = { version = "0.48.1", features = ["tracing", "logs"] }
 dotenvy_macro = "0.15.7"
 keyring = { version = "3.6.3", features = [
   "windows-native",

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -24,7 +24,7 @@ import { useContext, useRef } from "react";
 
 import { SplashscreenRoute } from "../pages/splashscreen";
 import { LandingRoute } from "../pages/landing";
-import { AuthContext } from "../contexts/auth";
+import { AuthContext } from "../contexts";
 
 export function Header() {
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/frontend/components/protected-route.tsx
+++ b/frontend/components/protected-route.tsx
@@ -1,7 +1,7 @@
 import { Navigate } from "@tanstack/react-router";
 import { ReactNode, useContext } from "react";
 
-import { AuthContext } from "../contexts/auth";
+import { AuthContext } from "../contexts";
 import { LoginRoute } from "../pages/login";
 import { Center, Flex, Spinner } from "@chakra-ui/react";
 import { Header } from "./header";
@@ -11,7 +11,7 @@ export const ProtectedRoute = ({ children }: { children: ReactNode }) => {
   // Safety: Context should exist, because provider is mounted at root.
   const { token } = useContext(AuthContext)!;
 
-  if (token.isFetching) {
+  if (token.isPending) {
     return (
       <>
         <Header />

--- a/frontend/contexts/auth.tsx
+++ b/frontend/contexts/auth.tsx
@@ -1,37 +1,31 @@
-import { createContext, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import {
-  useMutation,
-  UseMutationResult,
-  useQuery,
-  UseQueryResult,
-} from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { verifyToken } from "../utils/fetch";
 import { setUser } from "@sentry/react";
-
-export const AuthContext = createContext<{
-  token: UseQueryResult<null | string, unknown>;
-  login: UseMutationResult<void, unknown, string, unknown>;
-  logout: UseMutationResult<void, unknown, void, unknown>;
-} | null>(null);
+import { AuthContext } from ".";
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  // Query to read token from the platform key storage (IPC)
+  // Memoize queryFn to prevent infinite re-fetching
+  const tokenQueryFn = useCallback(async () => {
+    const token = await invoke<null | string>("get_authorization_token");
+    if (token) {
+      try {
+        await verifyToken(token);
+      } catch (e) {
+        console.error(e);
+        return null;
+      }
+      setUser({ id: token });
+      return token;
+    }
+    return null;
+  }, []);
+
   const token = useQuery({
     queryKey: ["authorizationToken"],
-    queryFn: async () => {
-      console.debug("Fetching authorization token from storage");
-      const token = await invoke<null | string>("get_authorization_token");
-      console.debug("Fetched authorization token:", token);
-      if (token) {
-        console.debug("verifying token");
-        await verifyToken(token);
-        console.debug("token verified");
-        setUser({ id: token });
-      }
-      return token ?? null;
-    },
+    queryFn: tokenQueryFn,
     // staleTime: Infinity,
     retry: false,
     refetchOnWindowFocus: false,

--- a/frontend/contexts/index.ts
+++ b/frontend/contexts/index.ts
@@ -1,0 +1,8 @@
+import { createContext } from "react";
+import type { UseMutationResult, UseQueryResult } from "@tanstack/react-query";
+
+export const AuthContext = createContext<{
+  token: UseQueryResult<null | string, unknown>;
+  login: UseMutationResult<void, unknown, string, unknown>;
+  logout: UseMutationResult<void, unknown, void, unknown>;
+} | null>(null);

--- a/frontend/pages/landing.tsx
+++ b/frontend/pages/landing.tsx
@@ -60,9 +60,7 @@ export function Landing() {
   if (examsQuery.isError) {
     return (
       <LandingParent>
-        <Text color="fcc.danger">
-          {getErrorMessage(examsQuery.error)}
-        </Text>
+        <Text color="fcc.danger">{getErrorMessage(examsQuery.error)}</Text>
         <Button
           variant={"danger"}
           onClick={() => {

--- a/frontend/pages/login.tsx
+++ b/frontend/pages/login.tsx
@@ -15,12 +15,11 @@ import { createRoute, useNavigate } from "@tanstack/react-router";
 import { Button, Spacer } from "@freecodecamp/ui";
 import { openUrl } from "@tauri-apps/plugin-opener";
 
-import { AuthContext } from "../contexts/auth";
+import { AuthContext } from "../contexts";
 import { Header } from "../components/header";
 import { rootRoute } from "./root";
 import { LandingRoute } from "./landing";
 import { LEARN_BASE } from "../utils/env";
-import { captureException } from "@sentry/react";
 import { getErrorMessage } from "../utils/errors";
 
 export function Login() {

--- a/frontend/utils/fetch.ts
+++ b/frontend/utils/fetch.ts
@@ -53,7 +53,7 @@ export async function verifyToken(token: string) {
     if (res.response.status !== 404 && res.response.status !== 418) {
       captureError(res);
     }
-    throw res.error;
+    throw new Error(res.error.message);
   }
 
   if (res.response.status >= 400) {
@@ -97,7 +97,7 @@ export async function getGeneratedExam(examId: string) {
     } else {
       captureError(res);
     }
-    throw res.error;
+    throw new Error(res.error.message);
   }
 
   const serverDateHeader = res.response.headers.get("Date");
@@ -118,7 +118,7 @@ export async function postExamAttempt(examAttempt: UserExamAttempt) {
       code: "EXAMPLE_ERROR",
       message: "Example error when posting exam",
     };
-    throw error;
+    throw new Error(error.message);
     // return undefined as never;
   }
 
@@ -141,7 +141,7 @@ export async function postExamAttempt(examAttempt: UserExamAttempt) {
     } else {
       captureError(res);
     }
-    throw res.error;
+    throw new Error(res.error.message);
   }
 
   return res.response;
@@ -183,7 +183,7 @@ export async function getExams() {
 
   if (res.error) {
     captureError(res);
-    throw res.error;
+    throw new Error(res.error.message);
   }
 
   return res.data;
@@ -207,7 +207,7 @@ export async function getAttemptsByExamId(examId: string) {
 
   if (res.error || res.response.status >= 300) {
     captureException(res.error);
-    throw res.error;
+    throw new Error("unable to get attempts for exam");
   }
 
   console.debug(res);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(async ({ mode }) => {
       strictPort: true,
       watch: {
         // 3. tell vite to ignore watching `backend`
-        ignored: ["**/backend/**"],
+        ignored: ["**/backend/**", "**/target/**"],
       },
     },
     define: {


### PR DESCRIPTION
I am still unsure why `verifyToken` throwing within the function causes the query to stall, but here we are 🤷‍♂️ 